### PR TITLE
EP "DEVELOPER_MANAGER_START" für eigene syncs als plugin..

### DIFF
--- a/config.inc.php
+++ b/config.inc.php
@@ -55,6 +55,7 @@ if (!$REX['REDAXO'] || is_object($REX['LOGIN'])) {
             $loggedIn = $REX['LOGIN']->checkLogin();
         }
         if ($loggedIn && $REX['LOGIN']->USER->isAdmin()) {
+            rex_register_extension_point('DEVELOPER_MANAGER_START','',array(),true);
             rex_developer_manager::start();
         }
     });


### PR DESCRIPTION
Moin Gregor,

hab die Tage ein bischen mit eigenen Syncs - in Form eines Plugins - rumgespielt.. hatte dabei aber folgendes prob: durch den reset von $REX bei Plugins fehlen der class rex_developer_synchronizer wenn sie aus dem Plugin heraus als parent aufgerufen wird die settings von Developer.. folglich wird dann z.b. basedir falsch gesetzt. Ein nochmaliger include der settings führte (was ich gerade nicht verstehe) dazu, daß sämtliche Einzel-settings plötzlich arrays waren.. vorbehaltlich einer anderen/schlaueren Lösung würde ich daher diesen EP vorschlagen.. damit klappts.
