### PR TITLE
Option zum Deaktivieren des Sync im Backend

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -6,7 +6,10 @@ if (method_exists('rex', 'getConsole') && rex::getConsole()) {
     return;
 }
 
-if (!rex::isBackend() && $this->getConfig('sync_frontend') || rex::getUser()) {
+if (
+    !rex::isBackend() && $this->getConfig('sync_frontend') ||
+    rex::getUser() && rex::isBackend() && $this->getConfig('sync_backend')
+) {
     rex_extension::register('PACKAGES_INCLUDED', function () {
         if (($user = rex_backend_login::createUser()) && $user->isAdmin()) {
             rex_developer_manager::start();

--- a/install.php
+++ b/install.php
@@ -8,6 +8,7 @@ if (!$this->hasConfig()) {
         'modules' => true,
         'actions' => true,
         'sync_frontend' => true,
+        'sync_backend' => true,
         'rename' => true,
         'prefix' => false,
         'umlauts' => true,

--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -4,6 +4,7 @@ developer_templates = Templates synchronisieren
 developer_modules = Module synchronisieren
 developer_actions = Actions synchronisieren
 developer_sync_frontend = Im Frontend synchronsieren (nur wenn als Admin in Backend eingeloggt)
+developer_sync_backend = Im Backend synchronsieren (nur wenn als Admin eingeloggt)
 developer_rename = Datei- und Ordnernamen aktuell halten
 developer_prefix = Präfix für Dateinamen (enthält ID und Name)
 developer_umlauts = Umlaute in Namen beibehalten

--- a/lang/en_gb.lang
+++ b/lang/en_gb.lang
@@ -4,6 +4,7 @@ developer_templates = Synchronize templates
 developer_modules = Synchronize modules
 developer_actions = Synchronize actions
 developer_sync_frontend = Synchronize in frontend (only if signed in as admin in backend)
+developer_sync_backend = Synchronize in backend (only if signed in as admin)
 developer_rename = Update file and directory names automatically
 developer_prefix = Filename prefix (contains ID and name)
 developer_umlauts = Keep umlauts in names

--- a/pages/index.php
+++ b/pages/index.php
@@ -10,6 +10,7 @@ if (rex_post('config-submit', 'boolean')) {
         ['modules', 'bool'],
         ['actions', 'bool'],
         ['sync_frontend', 'bool'],
+        ['sync_backend', 'bool'],
         ['rename', 'bool'],
         ['prefix', 'bool'],
         ['umlauts', 'bool'],
@@ -41,6 +42,11 @@ $formElements[] = $n;
 $n = [];
 $n['label'] = '<label for="rex-developer-sync-frontend">' . $this->i18n('sync_frontend') . '</label>';
 $n['field'] = '<input type="checkbox" id="rex-developer-sync-frontend" name="config[sync_frontend]" value="1" ' . ($this->getConfig('sync_frontend') ? ' checked="checked"' : '') . ' />';
+$formElements[] = $n;
+
+$n = [];
+$n['label'] = '<label for="rex-developer-sync-backend">' . $this->i18n('sync_backend') . '</label>';
+$n['field'] = '<input type="checkbox" id="rex-developer-sync-backend" name="config[sync_backend]" value="1" ' . ($this->getConfig('sync_backend') ? ' checked="checked"' : '') . ' />';
 $formElements[] = $n;
 
 $n = [];

--- a/update.php
+++ b/update.php
@@ -13,3 +13,7 @@ if (rex_string::versionCompare($this->getVersion(), '3.4.1', '<')) {
 if (rex_string::versionCompare($this->getVersion(), '3.5.0', '<')) {
     $this->setConfig('sync_frontend', true);
 }
+
+if (rex_string::versionCompare($this->getVersion(), '3.6.0', '<')) {
+    $this->setConfig('sync_backend', true);
+}


### PR DESCRIPTION
Als Ergänzung zu #40, sodass man auch ausschließlich manuell, über den Konsolen-Befehl synchronisieren kann. (Vor allem für den Live-Server sinnvoll, dort dann nur direkt beim Deployment einmal zu syncen).