### PR TITLE
Neuer Modus FORCE_FILES

### DIFF
--- a/lib/command.php
+++ b/lib/command.php
@@ -1,6 +1,8 @@
 <?php
 
+use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class rex_developer_command extends rex_console_command
@@ -10,6 +12,8 @@ class rex_developer_command extends rex_console_command
         $this
             ->setName('developer:sync')
             ->setDescription('Synchronizes the developer files')
+            ->addOption('force-db', null, InputOption::VALUE_NONE, 'Force the current status in db, files will be overridden')
+            ->addOption('force-files', null, InputOption::VALUE_NONE, 'Force the current status in file system, db data will be overridden')
         ;
     }
 
@@ -19,7 +23,21 @@ class rex_developer_command extends rex_console_command
 
         $io->title('Developer Sync');
 
-        rex_developer_manager::start();
+        $forceDb = $input->getOption('force-db');
+        $forceFiles = $input->getOption('force-files');
+
+        if ($forceDb && $forceFiles) {
+            throw new InvalidArgumentException('Options --force-db and --force-files can not be used at once.');
+        }
+
+        $force = false;
+        if ($forceDb) {
+            $force = rex_developer_synchronizer::FORCE_DB;
+        } elseif ($forceFiles) {
+            $force = rex_developer_synchronizer::FORCE_FILES;
+        }
+
+        rex_developer_manager::start($force);
 
         $io->success('Synchronized developer files.');
     }

--- a/lib/manager.php
+++ b/lib/manager.php
@@ -55,10 +55,12 @@ abstract class rex_developer_manager
                 array('content' => 'template.php'),
                 array('active' => 'boolean', 'attributes' => 'json')
             );
-            $synchronizer->setEditedCallback(function (rex_developer_synchronizer_item $item) {
+            $callback = function (rex_developer_synchronizer_item $item) {
                 $template = new rex_template($item->getId());
                 $template->deleteCache();
-            });
+            };
+            $synchronizer->setEditedCallback($callback);
+            $synchronizer->setDeletedCallback($callback);
             self::register(
                 $synchronizer,
                 $page == 'templates' && ((($function == 'add' || $function == 'edit') && $save == 'ja') || $function == 'delete')
@@ -71,20 +73,22 @@ abstract class rex_developer_manager
                 rex::getTable('module'),
                 array('input' => 'input.php', 'output' => 'output.php')
             );
-            $synchronizer->setEditedCallback(function (rex_developer_synchronizer_item $item) {
+            $callback = function (rex_developer_synchronizer_item $item) {
                 $sql = rex_sql::factory();
                 $sql->setQuery('
                     SELECT     DISTINCT(article.id)
-                    FROM       ' . rex::getTable('article') . ' article
-                    LEFT JOIN  ' . rex::getTable('article_slice') . ' slice
+                    FROM       '.rex::getTable('article').' article
+                    LEFT JOIN  '.rex::getTable('article_slice').' slice
                     ON         article.id = slice.article_id
-                    WHERE      slice.module_id=' . $item->getId()
+                    WHERE      slice.module_id='.$item->getId()
                 );
                 for ($i = 0, $rows = $sql->getRows(); $i < $rows; ++$i) {
                     rex_article_cache::delete($sql->getValue('article.id'));
                     $sql->next();
                 }
-            });
+            };
+            $synchronizer->setEditedCallback($callback);
+            $synchronizer->setDeletedCallback($callback);
             self::register(
                 $synchronizer,
                 $page == 'modules/modules' && ((($function == 'add' || $function == 'edit') && $save == '1') || $function == 'delete')
@@ -109,27 +113,29 @@ abstract class rex_developer_manager
      * Starts the main developer process
      *
      * The method registers the default synchronizers and the extensions which will start the synchronizer objects
+     *
+     * @param bool|int $force Flag, whether the synchronizers should run in force mode (`rex_developer_synchronizer::FORCE_DB/FILES`)
      */
-    public static function start()
+    public static function start($force = false)
     {
         rex_extension::registerPoint(new rex_extension_point('DEVELOPER_MANAGER_START', '', [], true));
 
         self::registerDefault();
 
         if (method_exists('rex', 'getConsole') && rex::getConsole()) {
-            self::synchronize();
+            self::synchronize(null, $force);
         } elseif (rex_be_controller::getCurrentPagePart(1) === 'backup' && rex_get('function', 'string') === 'dbimport') {
             rex_extension::register('BACKUP_AFTER_DB_IMPORT', function () {
-                rex_developer_manager::synchronize(null, true);
+                rex_developer_manager::synchronize(null, rex_developer_synchronizer::FORCE_DB);
             });
         } elseif (rex_be_controller::getCurrentPagePart(1) === 'developer' && rex_get('function', 'string') === 'update') {
             rex_extension::register('RESPONSE_SHUTDOWN', function () {
-                rex_developer_manager::synchronize(null, true);
+                rex_developer_manager::synchronize(null, rex_developer_synchronizer::FORCE_DB);
             });
         } else {
-            self::synchronize(self::START_EARLY);
-            rex_extension::register('RESPONSE_SHUTDOWN', function () {
-                rex_developer_manager::synchronize(self::START_LATE);
+            self::synchronize(self::START_EARLY, $force);
+            rex_extension::register('RESPONSE_SHUTDOWN', function () use ($force) {
+                rex_developer_manager::synchronize(self::START_LATE, $force);
             });
         }
     }
@@ -138,7 +144,7 @@ abstract class rex_developer_manager
      * Runs the synchronizer objects
      *
      * @param int|null $type  Flag, which synchronizers should start. If the value is null, all synchronizers will start
-     * @param bool     $force Flag, whether the synchronizers should run in force mode or not
+     * @param bool|int $force Flag, whether the synchronizers should run in force mode (`rex_developer_synchronizer::FORCE_DB/FILES`)
      * @see rex_developer_synchronizer::run
      */
     public static function synchronize($type = null, $force = false)

--- a/lib/synchronizer_default.php
+++ b/lib/synchronizer_default.php
@@ -17,6 +17,7 @@ class rex_developer_synchronizer_default extends rex_developer_synchronizer
     protected $metadata;
     protected $addedCallback;
     protected $editedCallback;
+    protected $deletedCallback;
     protected $idColumn = 'id';
     protected $nameColumn = 'name';
     protected $updatedColumn = 'updatedate';
@@ -57,6 +58,16 @@ class rex_developer_synchronizer_default extends rex_developer_synchronizer
     public function setEditedCallback($callback)
     {
         $this->editedCallback = $callback;
+    }
+
+    /**
+     * Sets a callback function which will be called if an existing item is deleted by the file system
+     *
+     * @param callable $callback
+     */
+    public function setDeletedCallback($callback)
+    {
+        $this->deletedCallback = $callback;
     }
 
     /**
@@ -221,6 +232,21 @@ class rex_developer_synchronizer_default extends rex_developer_synchronizer
         $sql->update();
         if ($this->editedCallback) {
             call_user_func($this->editedCallback, $item);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function deleteItem(rex_developer_synchronizer_item $item)
+    {
+        $sql = rex_sql::factory();
+        $sql->setTable($this->table);
+        $sql->setWhere([$this->idColumn => $item->getId()]);
+        $sql->delete();
+
+        if ($this->deletedCallback) {
+            call_user_func($this->deletedCallback, $item);
         }
     }
 


### PR DESCRIPTION
Bisher gibt es zwei Modi für die Synchronisation.
Der normale Modus, wo je nach Zeitstempel der DB-Datensatz oder die Datei gewinnt.
Und dann gibt es den force-Mode, wo immer die DB gewinnt. Dieser wird zum Beispiel nach einem Backup-Import ausgeführt.

Für YDeploy benötigt ich aber das Gegenteil, einen force-Mode, wo die Dateien gewinnen: https://github.com/yakamara/ydeploy/issues/7
Beim Deployen soll der per Dateien aufgespielte Stand garantiert werden.

Daher schlage ich vor, den force-Mode zu trennen in `FORCE_DB` und `FORCE_FILES`.
YDeploy würde dann `redaxo/bin/console developer:sync --force-files` nutzen.