### PR TITLE
Write missing lang keys to lang-file

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -57,3 +57,9 @@ rex_extension::register('EDITOR_URL', function (rex_extension_point $ep) {
 
     return rex_editor::factory()->getUrl($files[0], $ep->getParam('line'));
 }, rex_extension::LATE);
+
+
+if (rex::isBackend() && rex::getUser()) {
+    // To Do: Checkbox anbieten
+    rex_extension::register('I18N_MISSING_TRANSLATION', ['rex_developer_manager','missing_translation_ep'], rex_extension::LATE);
+}

--- a/lib/manager.php
+++ b/lib/manager.php
@@ -191,4 +191,19 @@ abstract class rex_developer_manager
             array_walk(self::$synchronizers[$type], $run);
         }
     }
+    
+    public static function missing_translation_ep($ep)
+    {
+        if ($lang = rex::getUser()->getLanguage() == "") {
+            $lang = rex::getProperty('lang');
+        }
+
+        $path = self::getBasePath() . 'lang'.DIRECTORY_SEPARATOR.'missing.'.$lang.'.lang';
+        $array = explode("\n", rex_file::get($path));
+
+        $array[] = $ep->getParam('key') ." = ";
+
+        rex_file::put($path, implode("\n", array_unique($array)));
+    }
+}
 }


### PR DESCRIPTION
beim Aufruf des EP  `I18N_MISSING_TRANSLATION` den fehlenden Key in das `data`-Verzeichnis von Developer schreiben: `\lang\missing.xx_XX.lang`, wobei `xx_XX` für den aktuell verwendeten Sprachcode im Backend steht.

So kann man durch das Browsen und Bedienen des Backends in der passenden Sprache alle nicht übersetzen Sprachkeys loggen.

Wie in https://github.com/redaxo/redaxo/issues/5433 angedacht als Arbeitsgrundlage, bereit für Verbesserungen. Evtl. muss das eine oder andere auch noch am EP selbst verbessert werden, aktuell wird der EP nicht an jeder Stelle, wo er sollte, gefeuert.

Auch wäre es sinnvoll, zu wissen, in welchem Kontext / aus welcher Datei oder Package heraus der sprachkey aufgerufen wurde - das könnte man als Kommentar hinter den Platzhalter schreiben.

Da in der Vergangenheit immer wieder PRs von mir ohne Angabe von Gründen nicht angenommen wurden, möchte ich hier es weiter machen, wenn es ein grundsätzlich positives Signal gibt.