### PR TITLE
Code-Icon hinzufügen `fa-code`

### DIFF
--- a/package.yml
+++ b/package.yml
@@ -6,6 +6,7 @@ supportpage: https://github.com/FriendsOfREDAXO/developer
 page:
     title: translate:name
     perm: admin
+    icon: rex-icon fa-code
     subpages:
         settings: { title: translate:settings }
         readme: { title: translate:readme, subPath: README.md }


### PR DESCRIPTION
Ehemals reserviert für Cronjob. Wenn https://github.com/redaxo/redaxo/pull/6074 angenommen wird, ist dieses Icon wieder frei.