### PR TITLE
replace empty string for module names

### DIFF
--- a/lib/synchronizer.php
+++ b/lib/synchronizer.php
@@ -301,6 +301,7 @@ abstract class rex_developer_synchronizer
 
         $name = preg_replace('@[\\\\|:<>?*"\'+]@', '', $name);
         $name = strtr($name, '[]/', '()-');
+        $name = strtr($name, ' ', '_');
 
         return ltrim(rtrim($name, ' .'));
     }


### PR DESCRIPTION
Replacing ' ' string with _ character for module names since it leads to problems with certain FTP clients. E.g VsCode SimpleFtp extension.
Could not synchronize the modules because of problems with module names containing " ".